### PR TITLE
Document scope, parameters, and usage of scripts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# openshift-utils
+# OpenShift utils
+
+## Script Documentation
+
+| Script Name | Description | Parameters | Example Usage |
+|-------------|-------------|------------|---------------|
+| `openshift_infra_ms.sh` | Creates an infrastructure MachineSet manifest for an OpenShift cluster. | None | `./openshift_infra_ms.sh` |
+| `openshift_monitoring_core.sh` | Configures Prometheus and AlertManager with persistent storage in OpenShift. | `-s, --storage-class` (default: gp3-csi), `-z, --storage-size` (default: 25Gi), `-r, --retention` (default: 15d), `-i, --infra-nodes` (default: false) | `./openshift_monitoring_core.sh -s gp3-csi -z 50Gi -r 30d -i true` |
+| `openshift_resources_report.sh` | Generates a CSV report of resource usage for deployments, deployment configs, stateful sets, and daemon sets in a specified namespace. | Namespace (first argument) | `./openshift_resources_report.sh my-namespace` |


### PR DESCRIPTION
Add documentation table to `README.md` for scripts in the repository.

* Add a table documenting the scope, parameters, and usage of each script.
* Include entries for `openshift_infra_ms.sh`, `openshift_monitoring_core.sh`, and `openshift_resources_report.sh`.
* Provide a brief description of each script, its parameters, and an example usage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dedalus-enterprise-architect/openshift-utils/pull/1?shareId=18c7fe9e-3054-4852-afb5-e494b8423efb).